### PR TITLE
sfml: audio component depends on system, bumped openal version

### DIFF
--- a/recipes/sfml/all/conanfile.py
+++ b/recipes/sfml/all/conanfile.py
@@ -44,7 +44,7 @@ class SFMLConan(ConanFile):
             self.requires('freetype/2.10.1')
             self.requires('stb/20200203')
         if self.options.audio:
-            self.requires('openal/1.19.1')
+            self.requires('openal/1.20.1')
             self.requires('flac/1.3.3')
             self.requires('ogg/1.3.4')
             self.requires('vorbis/1.3.6')
@@ -105,8 +105,6 @@ class SFMLConan(ConanFile):
         cmake.install()
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        os.remove(os.path.join(self.package_folder, "license.md"))
-        os.remove(os.path.join(self.package_folder, "readme.md"))
 
     def _get_decorated_lib(self, name):
         suffix = '-s' if not self.options.shared else ''
@@ -181,7 +179,7 @@ class SFMLConan(ConanFile):
 
         if self.options.audio:
             self.cpp_info.components["audio"].libs = [self._get_decorated_lib("sfml-audio")]
-            self.cpp_info.components["audio"].requires = ["openal::openal", "flac::flac", "ogg::ogg", "vorbis::vorbis"]
+            self.cpp_info.components["audio"].requires = ["openal::openal", "flac::flac", "ogg::ogg", "vorbis::vorbis", "system"]
             if not self.options.shared:
                 self.cpp_info.components["audio"].defines = ['SFML_STATIC']
             if self.settings.os == "Android":

--- a/recipes/sfml/all/patches/001_disable_deps_installation.patch
+++ b/recipes/sfml/all/patches/001_disable_deps_installation.patch
@@ -1,6 +1,12 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -404,62 +404,9 @@
+@@ -398,68 +398,12 @@
+             COMPONENT devel)
+ endif()
+
+-install(FILES license.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
+-install(FILES readme.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
+-
  # install 3rd-party libraries and tools
  if(SFML_OS_WINDOWS)
 
@@ -63,7 +69,7 @@
 
      # install the Xcode templates if requested
      if(SFML_INSTALL_XCODE_TEMPLATES)
-@@ -479,34 +426,9 @@
+@@ -479,34 +423,9 @@
  elseif(SFML_OS_IOS)
 
      # fix CMake install rules broken for iOS (see http://public.kitware.com/Bug/view.php?id=12506)


### PR DESCRIPTION
Bumped version of OpenAL to 1.20.1. This fixes a duplicate symbol error when OpenAL 1.19.1 is built on GCC 10. It now sets `-fno-common` by default which breaks OpenAL due to a few missing `extern`s in its headers. 1.20.1 doesn't have this issue.

Added missing "system" component require for the "audio" component.

Removed the `os.remove` commands as they don't seem to be needed and had caused the packaging to fail otherwise.